### PR TITLE
listCols should be optional

### DIFF
--- a/dist/sprestlib.d.ts
+++ b/dist/sprestlib.d.ts
@@ -35,7 +35,7 @@ declare namespace sprLib {
     requestDigest?: string;
   }
   interface ListItemsOptions {
-    listCols: Array<string> | Object;
+    listCols?: Array<string> | Object;
     metadata?: boolean;
     queryFilter?: string;
     queryLimit?: number;


### PR DESCRIPTION
According to the documentation 
> Omitting the listCols option will result in all List columns being returned (mimic SharePoint default behavior)

This patch makes the TypeScript listCols definition optional so it can be omitted.